### PR TITLE
Added repository "name with Owner" to config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,9 @@ google_analytics: G-NHE0NG5KTF
 lang: en
 favicon: assets/img/elio.jpg
 
+# Repository to keep Github Actions and Pages happy
+repository: elioquinton/elioquinton.github.io
+
 # Author info for SEO
 author:
     name: Elio Quinton


### PR DESCRIPTION
This is to keep GitHub Pages deployment via actions happy. CF http://jekyll.github.io/github-metadata/configuration/